### PR TITLE
Cow-ify token repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cowprotocol/contracts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,8 +13,8 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
       - id: yarn-cache

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,16 +7,13 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@cowprotocol'
       - run: yarn --frozen-lockfile
       - run: bash src/workflows/publish.sh
         env:
-          PUBLISH_SERVER: ${{ secrets.PUBLISH_SERVER }}
-          GITLAB_TRIGGER_TOKEN: ${{ secrets.GITLAB_TRIGGER_TOKEN }}
-          BUCKET_NAME: ${{ secrets.BUCKET_NAME }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ${{ secrets.AWS_REGION }}
+          NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -209,10 +209,10 @@ yarn hardhat compute-merkle-root --claims <path to csv>
 
 ## Use the code in another project
 
-The Solidity contract code, contract ABIs, and Typescript library code are available through the NPM package `@gnosis.pm/cow-token`.
+The Solidity contract code, contract ABIs, and Typescript library code are available through the NPM package `@cowprotocol/token`.
 
 If your project uses yarn, you can install this package with:
 
 ```sh
-yarn add @gnosis.pm/cow-token
+yarn add @cowprotocol/token
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@gnosis.pm/cow-token",
-  "version": "1.0.3",
+  "name": "@cowprotocol/token",
+  "version": "1.1.0",
   "license": "LGPL-3.0-or-later",
   "scripts": {
     "verify": "hardhat verify-contract-code",

--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -16,7 +16,7 @@ package_exists () {
   npm view --json "$1" &>/dev/null;
 }
 
-fail_if_unset NPM_AUTH_TOKEN
+fail_if_unset NODE_AUTH_TOKEN
 
 git_username="GitHub Actions"
 git_useremail="GitHub-Actions@cow.fi"

--- a/src/workflows/publish.sh
+++ b/src/workflows/publish.sh
@@ -16,15 +16,10 @@ package_exists () {
   npm view --json "$1" &>/dev/null;
 }
 
-fail_if_unset GITLAB_TRIGGER_TOKEN
-fail_if_unset BUCKET_NAME
-fail_if_unset PUBLISH_SERVER
-fail_if_unset AWS_ACCESS_KEY_ID
-fail_if_unset AWS_SECRET_ACCESS_KEY
-fail_if_unset AWS_REGION
+fail_if_unset NPM_AUTH_TOKEN
 
 git_username="GitHub Actions"
-git_useremail="GitHub-Actions@CoW-Token"
+git_useremail="GitHub-Actions@cow.fi"
 
 package_name="$(jq --raw-output .name ./package.json)"
 version="$(jq --raw-output .version ./package.json)"
@@ -41,29 +36,7 @@ if git fetch --end-of-options origin "refs/tags/$version_tag" 2>/dev/null; then
   exit 1
 fi
 
-yarn pack --filename package.tgz
-
-aws configure set aws_access_key_id "$AWS_ACCESS_KEY_ID"
-aws configure set aws_secret_access_key "$AWS_SECRET_ACCESS_KEY"
-aws configure set region "$AWS_REGION"
-if ! aws s3 cp package.tgz "s3://$BUCKET_NAME/cow-token/cow-token-$version.tgz"; then
-  echo "Failed upload to aws"
-  exit 1
-fi
-
-if ! pipeline_url="$(\
-     curl --silent --request POST \
-       --form-string "token=$GITLAB_TRIGGER_TOKEN" \
-       --form-string "ref=master" \
-       --form-string "variables[PROJECT]=$package_name" \
-       --form-string "variables[VERSION]=$version" \
-       --form-string "variables[TOKEN]=$GITLAB_TRIGGER_TOKEN" \
-       "$PUBLISH_SERVER" \
-       | jq -e '.web_url'\
-     )"; then
-  echo "Error triggering publish request"
-  exit 1
-fi
+yarn publish
 
 if ! git config --get user.name &>/dev/null; then
   git config user.name "$git_username"
@@ -73,5 +46,4 @@ git tag -m "Version $version" --end-of-options "$version_tag"
 
 git push origin "refs/tags/$version_tag"
 
-echo "Package $package_name version $version successfully submitted for publication."
-echo "Progress can be tracked here: $pipeline_url"
+echo "Package $package_name version $version successfully published."


### PR DESCRIPTION
This PR changes the package name from `@gnosis.pm/cow-token` to `@cowprotocol/token` and adjusts the publishing workflow for publishing directly from GitHub.

GitHub Actions workflow changes base on: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-using-yarn

### Test Plan

Deploy with GitHub action 🎉.
