### PR TITLE
Update deprecated dependency @gnosis.pm/safe-deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,10 +33,10 @@
     "ethers": "^5.6.1"
   },
   "devDependencies": {
-    "@gnosis.pm/safe-deployments": "^1.19.0",
     "@nomiclabs/hardhat-ethers": "^2.0.5",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@nomiclabs/hardhat-waffle": "^2.0.3",
+    "@safe-global/safe-deployments": "^1.28.0",
     "@types/chai": "^4.3.0",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^9.1.0",

--- a/src/tasks/ts/safe.ts
+++ b/src/tasks/ts/safe.ts
@@ -6,11 +6,11 @@ import {
   MetaTransaction,
 } from "@gnosis.pm/safe-contracts";
 import GnosisSafe from "@gnosis.pm/safe-contracts/build/artifacts/contracts/GnosisSafe.sol/GnosisSafe.json";
-import CompatibilityFallbackHandlerDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/compatibility_fallback_handler.json";
-import CreateCallDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/create_call.json";
-import GnosisSafeDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/gnosis_safe.json";
-import MultiSendDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/multi_send_call_only.json";
-import GnosisSafeProxyFactoryDeployment from "@gnosis.pm/safe-deployments/src/assets/v1.3.0/proxy_factory.json";
+import CompatibilityFallbackHandlerDeployment from "@safe-global/safe-deployments/src/assets/v1.3.0/compatibility_fallback_handler.json";
+import CreateCallDeployment from "@safe-global/safe-deployments/src/assets/v1.3.0/create_call.json";
+import GnosisSafeDeployment from "@safe-global/safe-deployments/src/assets/v1.3.0/gnosis_safe.json";
+import MultiSendDeployment from "@safe-global/safe-deployments/src/assets/v1.3.0/multi_send_call_only.json";
+import GnosisSafeProxyFactoryDeployment from "@safe-global/safe-deployments/src/assets/v1.3.0/proxy_factory.json";
 import { Contract, Signer, Wallet } from "ethers";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -568,13 +568,6 @@
   resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-contracts/-/safe-contracts-1.3.0.tgz#316741a7690d8751a1f701538cfc9ec80866eedc"
   integrity sha512-1p+1HwGvxGUVzVkFjNzglwHrLNA67U/axP0Ct85FzzH8yhGJb4t9jDjPYocVMzLorDoWAfKicGy1akPY9jXRVw==
 
-"@gnosis.pm/safe-deployments@^1.19.0":
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/safe-deployments/-/safe-deployments-1.19.0.tgz#f4ba8cf92cd6fdff4241ac50e410b4a6ff89babe"
-  integrity sha512-EvHR/LjMwJm0QKXyTscRXqR9vnJwCUDiMnRNKRyXe1akW+udiYXjJTAiGuleFS4DOUSqs6DpAjYlLnXMzUsVMw==
-  dependencies:
-    semver "^7.3.7"
-
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.9.2.tgz#68be55c737023009dfc5fe245d51181bb6476914"
@@ -691,6 +684,13 @@
     hosted-git-info "^2.6.0"
     path-browserify "^1.0.0"
     url "^0.11.0"
+
+"@safe-global/safe-deployments@^1.28.0":
+  version "1.28.0"
+  resolved "https://registry.yarnpkg.com/@safe-global/safe-deployments/-/safe-deployments-1.28.0.tgz#9984b513999e5a1cd4449ed2c1ba9a66cb5b223c"
+  integrity sha512-zWn55unMucN3i3awjDA0XxH9BzGNHyC/qCbuISBh0GMZP/q+VCxERAOEO4OqwyGaxk6sSAzP4usGdmgz2y2svg==
+  dependencies:
+    semver "^7.3.7"
 
 "@sentry/core@5.30.0":
   version "5.30.0"


### PR DESCRIPTION
Acting on [this comment](https://github.com/cowprotocol/token/pull/5#pullrequestreview-1761294365) by @mfw78.

As seen [here](https://www.npmjs.com/package/@gnosis.pm/safe-deployments), `@gnosis.pm/safe-deployments` is deprecated:

```
This package has been deprecated

Author message:
WARNING: This project has been renamed to @safe-global/safe-deployments . Please, update your dependencies
```

This PR removes the old package, adds the new one, and updates imports and version.

I also wanted to update [`@gnosis.pm/safe-contracts`](https://www.npmjs.com/package/@gnosis.pm/safe-contracts?activeTab=readme), but interestingly that package isn't deprecated. [`@safe-global/safe-contracts` ](https://www.npmjs.com/package/@safe-global/safe-contracts) exists, but old versions aren't available and the readme says "This branch contains changes that are under development" (this is probably just because the current tag is a dev tag).

### Test Plan

CI (it compiles). Also, try to run the `test-deployment` task, which relies on this package.