### PR TITLE
Add Gnosisscan verification support

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ For verifying the deployed contracts on Etherscan:
 
 ```sh
 export INFURA_KEY='insert your Infura key here'
-export ETHERSCAN_API_KEY='insert your Etherscan API key here'
+export ETHERSCAN_API_KEY='insert your Etherscan/Gnosisscan/... API key here'
 yarn verify --virtual-token $VIRTUAL_TOKEN_ADDRESS --network $NETWORK
 ```
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -128,7 +128,7 @@ export default {
   },
   etherscan: {
     apiKey: {
-      xdai: "any api key is good currently",
+      gnosis: ETHERSCAN_API_KEY,
       mainnet: ETHERSCAN_API_KEY,
       rinkeby: ETHERSCAN_API_KEY,
       goerli: ETHERSCAN_API_KEY,


### PR DESCRIPTION
Some changes needed to make the verification script work after the default block explorer changed from Blockscout to S

Unfortunately, the script still doesn't work:

<details><summary>yarn verify --virtual-token 0xc20c9c13e853fc64d054b73ff21d3636b2d97eab --network gnosischain</summary>

```
yarn run v1.22.19
$ hardhat verify-contract-code --virtual-token 0xc20c9c13e853fc64d054b73ff21d3636b2d97eab --network gnosischain
Verifying contract CowProtocolVirtualToken at address 0xc20c9c13e853fc64d054b73ff21d3636b2d97eab
Compiling 56 files with 0.8.10
Solidity compilation finished successfully
Compiling 1 file with 0.8.10
Successfully submitted source code for contract
src/contracts/CowProtocolVirtualToken.sol:CowProtocolVirtualToken at 0xc20c9c13e853fc64d054b73ff21d3636b2d97eab
for verification on the block explorer. Waiting for verification result...

Error in plugin @nomiclabs/hardhat-etherscan: The Etherscan API responded with a failure status.
The verification may still succeed but should be checked manually.
Reason: Fail - Unable to verify. Compiled contract deployment bytecode does NOT match the transaction deployment bytecode.

For more info run Hardhat with --show-stack-traces
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
</details>

I compared the bytecode in `build/` with the bytecode you can get from the [deployment transaction](https://dashboard.tenderly.co/tx/xdai/0x1e44e9e0d1372e2b10093c59a37c6d078f27241ce3f83dc6ebc13bdd97ec5e59/debugger?trace=0.1.11.3.0.3.2) and it matches perfectly, which is surprising since verification fails.

To make sure everything is right, I tried to use Foundry to verify the contract code with the following config:

<details><summary>foundry.toml</summary>

```toml
[profile.default]
src = "src/contracts"
out = "out"
libs = ["lib"]
solc-version = "0.8.10"
optimizer = true
optimizer-runs = 1000000
```
</details>

<details><summary>I was able to verify the contract code on <a href="https://repo.sourcify.dev/contracts/full_match/100/0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB/">Sourcify</a></summary>

```sh
$ forge verify-contract --verifier sourcify --chain-id 100 --etherscan-api-key "any" --constructor-args $(cast abi-encode 'f(bytes32,address,address,address,address,uint256,address,uint256,address,uint256,address)' 0x2a98e5d45ac55c620f0dcd227cf2b13b4d88aca6d0cf7845a0a8e08b95f9a2b3 0x177127622c4A00F3d409B75571e12cB3c8973d3c 0xcA771eda0c70aA7d053aB1B25004559B918FE662 0x0000000000000000000000000000000000000000 0x0000000000000000000000000000000000000000 0 0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb 585937500000000 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d 150000000000000000 0x0000000000000000000000000000000000000000) 0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB CowProtocolVirtualToken
Start verifying contract `0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB` deployed on xdai

Submitting verification for [CowProtocolVirtualToken] "0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB".
Contract successfully verified
```
</details>


<details><summary>But not on <a href="https://gnosisscan.io/address/0xc20c9c13e853fc64d054b73ff21d3636b2d97eab#code">Gnosisscan</a></summary>

```sh
$  forge verify-contract --chain-id 100 --etherscan-api-key "$ETHERSCAN_API_KEY" --constructor-args $(cast abi-encode 'f(bytes32,address,address,address,address,uint256,address,uint256,ad
dress,uint256,address)' 0x2a98e5d45ac55c620f0dcd227cf2b13b4d88aca6d0cf7845a0a8e08b95f9a2b3 0x177127622c4A00F3d409B75571e12cB3c8973d3c 0xcA771eda0c70aA7d053aB1B25004559B918FE662 0x00000000000000000000000
00000000000000000 0x0000000000000000000000000000000000000000 0 0x9C58BAcC331c9aa871AFD802DB6379a98e80CEdb 585937500000000 0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d 150000000000000000 0x0000000000000000
000000000000000000000000) 0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB CowProtocolVirtualToken
Start verifying contract `0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB` deployed on xdai

Submitting verification for [src/contracts/CowProtocolVirtualToken.sol:CowProtocolVirtualToken] 0xc20C9C13E853fc64d054b73fF21d3636B2d97eaB.
Submitted contract for verification:
        Response: `OK`
        GUID: `kyptpvhj2rhzqscb4tpqegjqsdgkjaixwhwmu59nrexdvvfiui`
        URL: https://gnosisscan.io/address/0xc20c9c13e853fc64d054b73ff21d3636b2d97eab
```
</details>

The error is weird: the response is an instant `OK`, while usually it takes some time before the contract is verified. Also, despite the `OK` you can't see the verified contract. The `OK` is also shown if I use some unrelated contract for verification, like `CowProtocolToken`.
Trying to verify with the web interface using the build artifact file returns `Sorry! We encountered an unexpected error.`.
At this point, my conclusion is that there currently are some issues with verifying contracts on Gnosisscan.

Still, these changes are more helpful than leaving everything as it is.